### PR TITLE
simple manifest change

### DIFF
--- a/client/Grouple/AndroidManifest.xml
+++ b/client/Grouple/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:targetSdkVersion="19" />
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <!-- GCM requires a Google account. -->
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />


### PR DESCRIPTION
Gallery and other forms of image choosing worked fine, but reading
directly through the file system or file picker option requires
READ_EXTERNAL_STORAGE permission.   Note:  I saw some other possible
ways to avoid needing this permission using strange android methods, but
want to avoid scope creep for such a minor item.
