### PR TITLE
Reproposed Event Functionality added

### DIFF
--- a/client/Grouple/src/cs460/grouple/grouple/EventCreateActivity.java
+++ b/client/Grouple/src/cs460/grouple/grouple/EventCreateActivity.java
@@ -407,7 +407,7 @@ public class EventCreateActivity extends BaseActivity
 				SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm");
 				try
 				{
-					endCal.setTime(sdf.parse(endDate));
+					endCal.setTime(sdf.parse(startDate));
 					System.out.println("cal was parsed from tmpStartDate!");
 				}
 				catch (ParseException e)

--- a/client/Grouple/src/cs460/grouple/grouple/EventProfileActivity.java
+++ b/client/Grouple/src/cs460/grouple/grouple/EventProfileActivity.java
@@ -463,6 +463,13 @@ public class EventProfileActivity extends BaseActivity
 			break;
 		case R.id.profileEditButton:
 			intent = new Intent(this, EventEditActivity.class);
+			//add reprososed extra if clicking this button when it says "repropose event" instead of "edit event"
+			if(!profileButton6.getText().toString().equals("Edit Event"))
+			{
+				System.out.println("adding reproposed extra!");
+				intent.putExtra("reproposed", 1);
+				finish();
+			}
 			break;
 		default:
 			break;


### PR DESCRIPTION
-user has ability to repropose a declined event that they created.
-all info from old event can be carried over minus start/end date.
-minor bug fix to enddate setter that was causing crash.
-changes to php of createEvent to handle incoming photo and additional
repropose info.
