### PR TITLE
Public/Private for Event, e_groups populating upon create

### DIFF
--- a/client/Grouple/res/layout/activity_event_create.xml
+++ b/client/Grouple/res/layout/activity_event_create.xml
@@ -244,7 +244,7 @@
                 android:id="@+id/minmaxContainer"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="@color/background_color"
+                android:background="@color/layout_background_color"
                 android:orientation="horizontal" >
 
                 <EditText
@@ -275,6 +275,40 @@
                     android:padding="10dp"
                     android:textColor="@color/text_color"
                     android:textColorHint="@color/hint_text_color" />
+            </LinearLayout>
+            
+             <TextView
+                android:id="@+id/publicLabelTextViewEPA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@color/black"
+                android:gravity="left"
+                android:padding="5dp"
+                android:text="Event privacy settings:"
+                android:textColor="@color/white" />
+
+            <LinearLayout
+                android:id="@+id/publicButtonContainer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/layout_background_color"
+                android:orientation="horizontal" >
+
+                <RadioButton
+                    android:id="@+id/publicButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:onClick="radio"
+                    android:text="Public" />
+
+                <RadioButton
+                    android:id="@+id/privateButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:onClick="radio"
+                    android:text="Private" />
             </LinearLayout>
 
             <Button

--- a/client/Grouple/res/layout/activity_event_edit.xml
+++ b/client/Grouple/res/layout/activity_event_edit.xml
@@ -272,6 +272,41 @@
                     android:textColor="@color/text_color"
                     android:textColorHint="@color/hint_text_color" />
             </LinearLayout>
+            
+             <TextView
+                android:id="@+id/publicLabelTextViewEPA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@color/black"
+                android:gravity="left"
+                android:padding="5dp"
+                android:text="Event privacy settings:"
+                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:textColor="@color/white" />
+
+            <LinearLayout
+                android:id="@+id/publicButtonContainer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/background_color"
+                android:orientation="horizontal" >
+
+                <RadioButton
+                    android:id="@+id/publicButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:onClick="radio"
+                    android:text="Public" />
+
+                <RadioButton
+                    android:id="@+id/privateButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:onClick="radio"
+                    android:text="Private" />
+            </LinearLayout>
 
             <TextView
                 android:id="@+id/errorTextView"

--- a/client/Grouple/src/cs460/grouple/grouple/EventCreateActivity.java
+++ b/client/Grouple/src/cs460/grouple/grouple/EventCreateActivity.java
@@ -56,6 +56,7 @@ import android.widget.DatePicker;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
+import android.widget.RadioButton;
 import android.widget.TextView;
 import android.widget.TimePicker;
 import android.widget.Toast;
@@ -87,6 +88,8 @@ public class EventCreateActivity extends BaseActivity
 	private AlertDialog recurringDialog;
 	private AlertDialog toBringDialog;
 	private Button addToBringRowButton;
+	private RadioButton publicButton;
+	private RadioButton privateButton;
 	private Button toBringButton;
 	private Bitmap bmp;
 	private ImageView iv;
@@ -100,7 +103,8 @@ public class EventCreateActivity extends BaseActivity
 	private int year, month, day, hour, minute;
 	private ArrayList<String> itemNames = new ArrayList<String>();
 	private String recurring;
-
+	int publicStatus;
+	
 	@Override
 	protected void onCreate(Bundle savedInstanceState)
 	{
@@ -125,12 +129,15 @@ public class EventCreateActivity extends BaseActivity
 		aboutEditText = (EditText) findViewById(R.id.eventAboutEditText);
 		nameEditText = (EditText) findViewById(R.id.eventNameEditText);
 		recurringButton = (EditText) findViewById(R.id.recurringButton);
+		publicButton = (RadioButton) findViewById(R.id.publicButton);
+		privateButton = (RadioButton) findViewById(R.id.privateButton);
 		iv = (ImageView) findViewById(R.id.eventCreateImageView);
 		eventEditImageButton = (Button) findViewById(R.id.eventEditImageButton);
 		// grab the email of current users from our GLOBAL class
 		user = GLOBAL.getCurrentUser();
 		initActionBar("Create Event", true);
 		recurring = "";
+		publicStatus = 1;
 	}
 
 	// onClick for items to bring
@@ -203,6 +210,28 @@ public class EventCreateActivity extends BaseActivity
 		}
 		toBringDialog.dismiss();
 		toBringButton.setText("Items (" + itemNames.size() + ")");
+	}
+	
+	//onClick for public/private buttons
+	public void radio (View view)
+	{
+		switch (view.getId())
+		{
+		case R.id.publicButton:
+			if (publicButton.isChecked())
+			{
+				privateButton.setChecked(false);
+			}
+				
+			break;
+		case R.id.privateButton:
+			
+			if (privateButton.isChecked())
+			{
+				publicButton.setChecked(false);
+			}
+			break;
+		}
 	}
 
 	// onClick for category button
@@ -481,6 +510,12 @@ public class EventCreateActivity extends BaseActivity
 		maximum = maximumEditText.getText().toString();
 		Date start = null;
 		Date end = null;
+						
+		//1 for public, 0 for private.		
+		if(privateButton.isChecked())
+		{
+			publicStatus = 0;
+		}
 
 		if (minimum.compareTo("") == 0)
 		{
@@ -611,6 +646,7 @@ public class EventCreateActivity extends BaseActivity
 						System.out.println("About to add start date as " + startDate);
 						builder.addTextBody("start_date", startDate,
 								ContentType.TEXT_PLAIN);
+						builder.addTextBody("public", Integer.toString(publicStatus), ContentType.TEXT_PLAIN);
 						builder.addTextBody("end_date", endDate, ContentType.TEXT_PLAIN);
 						builder.addTextBody("recurring", recurring, ContentType.TEXT_PLAIN);
 						builder.addTextBody("category", category, ContentType.TEXT_PLAIN);
@@ -696,7 +732,8 @@ public class EventCreateActivity extends BaseActivity
 									// can be sent to correct event id)
 									Intent intent = new Intent(EventCreateActivity.this, EventAddGroupsActivity.class);
 									intent.putExtra("CONTENT", "EVENT");
-									intent.putExtra("e_id", ID);
+									
+									intent.putExtra("e_id", Integer.parseInt(ID));
 									intent.putExtra("email", user.getEmail());
 									startActivity(intent);
 									finish();

--- a/client/Grouple/src/cs460/grouple/grouple/EventEditActivity.java
+++ b/client/Grouple/src/cs460/grouple/grouple/EventEditActivity.java
@@ -52,6 +52,7 @@ import android.widget.DatePicker;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
+import android.widget.RadioButton;
 import android.widget.TextView;
 import android.widget.TimePicker;
 import android.widget.Toast;
@@ -88,12 +89,15 @@ public class EventEditActivity extends BaseActivity
 	private TextView errorTextView;
 	private AlertDialog toBringDialog;
 	private Button addToBringRowButton;
+	private RadioButton privateButton;
+	private RadioButton publicButton;
 	private Button toBringButton;
 	private Button manageEventButton;
 	private Button submitButton;
 	private View toBringLayout;
 	private String recurring;
 	private User user;
+	private int publicStatus;
 	private final ArrayList<EditText> toBringEditTexts = new ArrayList<EditText>();
 	private ArrayList<EventItem> items = new ArrayList<EventItem>();
 
@@ -125,6 +129,9 @@ public class EventEditActivity extends BaseActivity
 		manageEventButton = (Button) findViewById(R.id.manageEventButton);
 		recurringButton = (EditText) findViewById(R.id.recurringButton);
 		submitButton = (Button) findViewById(R.id.submitButton);
+		publicButton = (RadioButton) findViewById(R.id.publicButton);
+		privateButton = (RadioButton) findViewById(R.id.privateButton);
+		publicStatus = 1;
 		// init variables
 		currentCal = Calendar.getInstance();
 		year = currentCal.get(Calendar.YEAR);
@@ -179,6 +186,16 @@ public class EventEditActivity extends BaseActivity
 		{
 			maxEditText.setText(String.valueOf(event.getMaxPart()));
 		}
+		//set the private/public radio buttons
+		if (event.getPub() == 1)
+		{
+			publicButton.setChecked(true);
+		}
+		else
+		{
+			privateButton.setChecked(true);
+		}
+			
 
 		toBringButton.setText("Items (" + items.size() + ")");
 		startEditText.setText(event.getStartText());
@@ -574,6 +591,28 @@ public class EventEditActivity extends BaseActivity
 		recurringDialog.show();
 
 	}
+	
+	//onClick for public/private radio buttons
+	public void radio(View view)
+	{
+		switch (view.getId())
+		{
+		case R.id.publicButton:
+			if (publicButton.isChecked())
+			{
+				System.out.println("Case public button and is checked.");
+				privateButton.setChecked(false);
+			}
+			break;
+		case R.id.privateButton:
+			if (privateButton.isChecked())
+			{
+				System.out.println("Case private button and is checked.");
+				publicButton.setChecked(false);
+			}
+			break;
+		}
+	}
 
 	// Button Listener for when user clicks on category.
 	public void selectCategoryButton(View view)
@@ -628,6 +667,12 @@ public class EventEditActivity extends BaseActivity
 		// Grab the data from the editTexts and push it to the database.
 		public String readJSONFeed(String URL)
 		{
+			//1 for public, 0 for private.		
+			if(privateButton.isChecked())
+			{
+				publicStatus = 0;
+			}
+			
 			StringBuilder stringBuilder = new StringBuilder();
 			HttpClient httpClient = new DefaultHttpClient();
 			// update_event.php using name/value pair
@@ -676,6 +721,7 @@ public class EventEditActivity extends BaseActivity
 				builder.addTextBody("start_date", startDate, ContentType.TEXT_PLAIN);
 				builder.addTextBody("end_date", endDate, ContentType.TEXT_PLAIN);
 				builder.addTextBody("recurring", recurring, ContentType.TEXT_PLAIN);
+				builder.addTextBody("public", Integer.toString(publicStatus), ContentType.TEXT_PLAIN);
 				builder.addTextBody("recurring_type", recurring, ContentType.TEXT_PLAIN);
 				builder.addTextBody("category", categoryEditText.getText().toString(), ContentType.TEXT_PLAIN);
 				builder.addTextBody("min_part", minEditText.getText().toString(), ContentType.TEXT_PLAIN);

--- a/client/Grouple/src/cs460/grouple/grouple/GroupEditActivity.java
+++ b/client/Grouple/src/cs460/grouple/grouple/GroupEditActivity.java
@@ -177,9 +177,15 @@ public class GroupEditActivity extends BaseActivity
 		aboutEditText.setText(group.getAbout());
 		System.out.println("group.getpub() value is: " + group.getPub());
 		if (group.getPub() == 1)
+		{
 			publicButton.setChecked(true);
+			privateButton.setChecked(false);
+		}	
 		else
+		{
+			publicButton.setChecked(false);
 			privateButton.setChecked(true);
+		}
 		if (group.getImage() != null)
 			iv.setImageBitmap(group.getImage());
 	}


### PR DESCRIPTION
-Added public/private buttons to create/edit event layouts
-Fixed bug in groupEdit related to public/private
-E_groups populates upon event creation and e_members add.
