### PR TITLE
Bug fixes / Removal of delete_reg_id call

### DIFF
--- a/client/Grouple/src/cs460/grouple/grouple/BaseActivity.java
+++ b/client/Grouple/src/cs460/grouple/grouple/BaseActivity.java
@@ -166,7 +166,12 @@ public class BaseActivity extends ActionBarActivity implements OnClickListener
 			break;
 		case R.id.action_logout:
 			//Remove RegID
-			new deleteRegIDTask().execute("http://68.59.162.183/android_connect/delete_chat_id.php", user.getEmail());
+			//We can never remove regid from database without replacing it with another.
+			//if a user does clear their reg id from db, any other users who are trying to message this user will no longer be able to fetch the user's reg_id to use in GCM calls.
+			//It is okay to have multiple emails linked to the same reg_id.  (This will be common for such as a user who has two accounts and switches between them on the same device)
+			//However we must not display push notifications if the GCM recipient is not the user who is currently logged in.  We will simply discard those GCMs if they are received.
+			
+			//new deleteRegIDTask().execute("http://68.59.162.183/android_connect/delete_chat_id.php", user.getEmail());
 			GLOBAL.destroySession();
 			intent = new Intent(this, LoginActivity.class);
 			Intent CLOSE_ALL = new Intent("CLOSE_ALL");
@@ -258,7 +263,9 @@ public class BaseActivity extends ActionBarActivity implements OnClickListener
 		return builder;
 	}
 	
-	//This task gets your friend's regid
+	//no one should ever be calling this method
+	/*
+	//This task deletes your stored regid
     private class deleteRegIDTask extends AsyncTask<String, Void, String>
 	{
 		@Override
@@ -293,4 +300,5 @@ public class BaseActivity extends ActionBarActivity implements OnClickListener
 			}
 		}
 	}
+	*/
 }

--- a/client/Grouple/src/cs460/grouple/grouple/EventEditActivity.java
+++ b/client/Grouple/src/cs460/grouple/grouple/EventEditActivity.java
@@ -190,10 +190,12 @@ public class EventEditActivity extends BaseActivity
 		if (event.getPub() == 1)
 		{
 			publicButton.setChecked(true);
+			privateButton.setChecked(false);
 		}
 		else
 		{
 			privateButton.setChecked(true);
+			publicButton.setChecked(false);
 		}
 			
 

--- a/client/Grouple/src/cs460/grouple/grouple/HomeActivity.java
+++ b/client/Grouple/src/cs460/grouple/grouple/HomeActivity.java
@@ -11,6 +11,8 @@ import org.json.JSONObject;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.DialogInterface;
+import android.content.DialogInterface.OnCancelListener;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
@@ -18,6 +20,7 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.os.Process;
 import android.preference.PreferenceManager;
 import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
@@ -66,10 +69,14 @@ public class HomeActivity extends BaseActivity
 			regid = getRegistrationId(context);
 			if (regid.isEmpty())
 			{
+				//Register then save to backend
 				registerInBackground();
 			}
-			//Store this in the backend, even though it may just store the same value.
-			sendRegistrationIdToBackend();
+			else
+			{
+				//Store this in the backend, even though it may just store the same value.
+				sendRegistrationIdToBackend();
+			}
 		} 
 		else
 		{
@@ -216,12 +223,22 @@ public class HomeActivity extends BaseActivity
 		{
 			if (GooglePlayServicesUtil.isUserRecoverableError(resultCode))
 			{
+				OnCancelListener playServicesCancel = new DialogInterface.OnCancelListener()
+				{
+
+					@Override
+					public void onCancel(DialogInterface dialog)
+					{
+						//could kill process here if they cancel the dialog however this is currently disabled to allow emulator development of the code.
+						//Process.killProcess(Process.myPid()); 
+					}
+				};
+				
 				GooglePlayServicesUtil.getErrorDialog(resultCode, this,
-						PLAY_SERVICES_RESOLUTION_REQUEST).show();
+						PLAY_SERVICES_RESOLUTION_REQUEST,playServicesCancel).show();
 			} else
 			{
-				Log.i(TAG, "This device is not supported.");
-				finish();
+				Process.killProcess(Process.myPid()); 
 			}
 			return false;
 		}
@@ -248,6 +265,7 @@ public class HomeActivity extends BaseActivity
 		editor.putString(PROPERTY_REG_ID, regId);
 		editor.putInt(PROPERTY_APP_VERSION, appVersion);
 		editor.commit();
+		sendRegistrationIdToBackend();
 	}
 
 	/**


### PR DESCRIPTION
-Removed delete_reg_id upon logout to prevent crashes in messaging.
More code for this coming soon.
-Fixed UI bug in editEventActivity in which both public and private
checkboxes were being shown as checked.
-Fixed timing bug in HomeActivity in which it was possible for reg_id to
have not been sent to database.
